### PR TITLE
Replace the tab with 4 spaces in proposals

### DIFF
--- a/docs/proposals/cluster-groups.md
+++ b/docs/proposals/cluster-groups.md
@@ -14,11 +14,11 @@ Groups are cluster-scoped sets of users that are managed by cluster-admins and m
 ```
 // Group contains the set of users that belong to a given Group.  The name may not contain ":"
 type Group struct {
-	kapi.TypeMeta
-	kapi.ObjectMeta
+    kapi.TypeMeta
+    kapi.ObjectMeta
 
-	// Users is a list of Users that are members of the Group
-	Users util.StringSet
+    // Users is a list of Users that are members of the Group
+    Users util.StringSet
 }
 ```
 

--- a/docs/proposals/label-associated-quota.md
+++ b/docs/proposals/label-associated-quota.md
@@ -12,33 +12,33 @@ objects.  By associating projects to owners using structured labels, it becomes 
 // ResourceQuota allocations to the set of selected projects from exceeding set limits.  If a single project is selected by multiple
 // ResourceQuotaAllocations, then the most restrictive limit wins.
 type ResourceQuotaAllocation struct{
-	unversioned.TypeMeta
-	kapi.ObjectMeta
+    unversioned.TypeMeta
+    kapi.ObjectMeta
 
-	Spec ResourceQuotaAllocationSpec
-	Status ResourceQuotaAllocationStatus
+    Spec ResourceQuotaAllocationSpec
+    Status ResourceQuotaAllocationStatus
 }
 
 type ResourceQuotaAllocationSpec struct{
-	// Selector is used to find the set of projects that this ResourceQuotaAllocation is for
-	Selector extensions.LabelSelector
+    // Selector is used to find the set of projects that this ResourceQuotaAllocation is for
+    Selector extensions.LabelSelector
 
-	// Allocation is the description of the maximum quota sizes allowed across all the selected projects
-	Allocation kapi.ResourceQuotaSpec
+    // Allocation is the description of the maximum quota sizes allowed across all the selected projects
+    Allocation kapi.ResourceQuotaSpec
 }
 
 type ResourceQuotaAllocationStatus struct{
-	// Allocated is the current state of usage across all selected projects
-	Allocated kapi.ResourceQuotaStatus
+    // Allocated is the current state of usage across all selected projects
+    Allocated kapi.ResourceQuotaStatus
 
-	// UsedByProject makes association for users a little easier AND it allows us to update only when needed.
-	UsedByProject NamespacedResourceList
+    // UsedByProject makes association for users a little easier AND it allows us to update only when needed.
+    UsedByProject NamespacedResourceList
 }
 
 type NamespacedResourceList struct{
-	Namespace string
+    Namespace string
 
-	Used kapi.ResourceList
+    Used kapi.ResourceList
 }
 
 ```

--- a/docs/proposals/ldap-group-sync.md
+++ b/docs/proposals/ldap-group-sync.md
@@ -51,7 +51,7 @@ An `LDAPGroupLister` determines what LDAP groups needs to be synced and outputs 
 // be paired with an LDAPGroupMemberExtractor that understands the format of the unique identifiers
 // returned to represent the LDAP groups to be synced.
 type LDAPGroupLister interface {
-	ListGroups() (groupUIDs []string, err error)
+    ListGroups() (groupUIDs []string, err error)
 }
 ```
 
@@ -61,9 +61,9 @@ An `LDAPGroupMemberExtractor` gathers information on an LDAP group based on an L
 ```go
 // LDAPGroupMemberExtractor retrieves data about an LDAP group from the LDAP server.
 type LDAPGroupMemberExtractor interface {
-	// ExtractMembers returns the list of LDAP first-class user entries that are members of the LDAP
-	// group specified by the groupUID
-	ExtractMembers(groupUID string) (members []*ldap.Entry, err error)
+    // ExtractMembers returns the list of LDAP first-class user entries that are members of the LDAP
+    // group specified by the groupUID
+    ExtractMembers(groupUID string) (members []*ldap.Entry, err error)
 }
 ```
 
@@ -73,7 +73,7 @@ The mapping of a LDAP member entry to an OpenShift `User` Name will be determini
 ```go
 // LDAPUserNameMapper maps an LDAP entry representing a user to the OpenShift User Name corresponding to it
 type LDAPUserNameMapper interface {
-	UserNameFor(ldapUser *ldap.Entry) (openShiftUserName string, err error)
+    UserNameFor(ldapUser *ldap.Entry) (openShiftUserName string, err error)
 }
 ```
 
@@ -90,7 +90,7 @@ type DeterministicUserIdentityMapper struct {
 }
 
 func (m *DeterministicUserIdentityMapper) UserFor(identity authapi.UserIdentityInfo) (user user.Info,
-	err error) {
+    err error) {
 }
 ```
 

--- a/docs/proposals/policy.md
+++ b/docs/proposals/policy.md
@@ -19,64 +19,64 @@ Policy extends the existing authorization rules in Kubernetes (https://github.co
 There are four fundamental roles: view, edit, admin, and cluster-admin.  Viewers are able to see all resources.  Editors are able to view and edit all resources, except ones related to policy and membership.  Admins are able to modify anything everything except policy rules.  Cluster-admins can modify aything.  The roles are expressed like this:
 ```
 {
-	"kind": "role",
-	"name": "view",
-	"namespace": "master",
-	"rules": [
-		{ "verbs": ["get", "list", "watch"], "resources": ["resourcegroup:exposedopenshift", "resourcegroup:allkube"] }
-	]
+    "kind": "role",
+    "name": "view",
+    "namespace": "master",
+    "rules": [
+        { "verbs": ["get", "list", "watch"], "resources": ["resourcegroup:exposedopenshift", "resourcegroup:allkube"] }
+    ]
 }
 {
-	"kind": "role",
-	"name": "edit",
-	"namespace": "master",
-	"rules": [
-		{ "verbs": ["get", "list", "watch", "create", "update", "delete"], "resources": ["resourcegroup:exposedopenshift", "resourcegroup:exposedkube"] }
-		{ "verbs": ["get", "list", "watch"], "resources": ["resourcegroup:allkube"] }
-	]
+    "kind": "role",
+    "name": "edit",
+    "namespace": "master",
+    "rules": [
+        { "verbs": ["get", "list", "watch", "create", "update", "delete"], "resources": ["resourcegroup:exposedopenshift", "resourcegroup:exposedkube"] }
+        { "verbs": ["get", "list", "watch"], "resources": ["resourcegroup:allkube"] }
+    ]
 }
 {
-	"kind": "role",
-	"name": "admin",
-	"namespace": "master",
-	"rules": [
-		{ "verbs": ["get", "list", "watch", "create", "update", "delete"], "resources": ["resourcegroup:exposedopenshift", "resourcegroup:granter", "resourcegroup:exposedkube"] }
-		{ "verbs": ["get", "list", "watch"], "resources": ["resourcegroup:policy", "resourcegroup:allkube"] }
-	]
+    "kind": "role",
+    "name": "admin",
+    "namespace": "master",
+    "rules": [
+        { "verbs": ["get", "list", "watch", "create", "update", "delete"], "resources": ["resourcegroup:exposedopenshift", "resourcegroup:granter", "resourcegroup:exposedkube"] }
+        { "verbs": ["get", "list", "watch"], "resources": ["resourcegroup:policy", "resourcegroup:allkube"] }
+    ]
 }
 {
-	"kind": "role",
-	"name": "cluster-admin",
-	"namespace": "master",
-	"rules": [
-		{ "verbs": ["*"], "resources": ["*"] }
-	]
+    "kind": "role",
+    "name": "cluster-admin",
+    "namespace": "master",
+    "rules": [
+        { "verbs": ["*"], "resources": ["*"] }
+    ]
 }
 ```
 
 `Clark` is the cluster admin: the guy who owns the openshift installation.  `Clark` creates a project `hammer` and assigns `Hubert` as the project admin using the predefined role.  The permissions are expressed like this:
 ```
 {
-	"kind": "roleBinding",
-	"name": "ProjectAdmins",
-	"namespace": "hammer",
-	"roleRef": {
-		"namespace": "master",
-		"name": "admin"
-	}
-	"userNames": ["Hubert"]
+    "kind": "roleBinding",
+    "name": "ProjectAdmins",
+    "namespace": "hammer",
+    "roleRef": {
+        "namespace": "master",
+        "name": "admin"
+    }
+    "userNames": ["Hubert"]
 }
 ```
 
 `Hubert` now has the power to manage policy on the `hammer` project.  He can grant permission to users who should have access.  In this case, he grants edit permission to `Edgar` using the predefined role.
 ```
 {
-	"kind": "roleBinding",
-	"name": "Editors",
-	"namespace": "hammer",
-	"referencesGlobalRole": true,
-	"roleName": "edit",
-	"userNames": ["Edgar"]
+    "kind": "roleBinding",
+    "name": "Editors",
+    "namespace": "hammer",
+    "referencesGlobalRole": true,
+    "roleName": "edit",
+    "userNames": ["Edgar"]
 }
 ```
 
@@ -106,70 +106,70 @@ These are the types used in the policy example above.  They allow us: to quickly
 // PolicyRule holds information that describes a policy rule, but does not contain information
 // about who the rule applies to or which namespace the rule applies to.
 type PolicyRule struct {
-	// Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
-	Verbs util.StringSet
-	// AttributeRestrictions will vary depending on what the Authorizer/AuthorizationAttributeBuilder pair supports.
-	// If the Authorizer does not recognize how to handle the AttributeRestrictions, the Authorizer should report an error.
-	AttributeRestrictions runtime.EmbeddedObject
-	// Resources is a list of resources this rule applies to.  ResourceAll represents all resources.
-	Resources util.StringSet
-	// ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
-	ResourceNames util.StringSet
+    // Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
+    Verbs util.StringSet
+    // AttributeRestrictions will vary depending on what the Authorizer/AuthorizationAttributeBuilder pair supports.
+    // If the Authorizer does not recognize how to handle the AttributeRestrictions, the Authorizer should report an error.
+    AttributeRestrictions runtime.EmbeddedObject
+    // Resources is a list of resources this rule applies to.  ResourceAll represents all resources.
+    Resources util.StringSet
+    // ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+    ResourceNames util.StringSet
 }
 
 // Role is a logical grouping of PolicyRules that can be referenced as a unit by RoleBindings.
 type Role struct {
-	kapi.TypeMeta
-	kapi.ObjectMeta
+    kapi.TypeMeta
+    kapi.ObjectMeta
 
-	// Rules holds all the PolicyRules for this Role
-	Rules []PolicyRule
+    // Rules holds all the PolicyRules for this Role
+    Rules []PolicyRule
 }
 
 // RoleBinding references a Role, but not contain it.  It can reference any Role in the same namespace or in the global namespace.
 // It adds who information via Users and Groups and namespace information by which namespace it exists in.  RoleBindings in a given
 // namespace only have effect in that namespace (excepting the master namespace which has power in all namespaces).
 type RoleBinding struct {
-	kapi.TypeMeta
-	kapi.ObjectMeta
+    kapi.TypeMeta
+    kapi.ObjectMeta
 
-	// Users holds all the usernames directly bound to the role
-	Users util.StringSet
-	// Groups holds all the groups directly bound to the role
-	Groups util.StringSet
+    // Users holds all the usernames directly bound to the role
+    Users util.StringSet
+    // Groups holds all the groups directly bound to the role
+    Groups util.StringSet
 
-	// Since Policy is a singleton, this is sufficient knowledge to locate a role
-	// RoleRefs can only reference the current namespace and the global namespace
-	// If the RoleRef cannot be resolved, the Authorizer must return an error.
-	RoleRef kapi.ObjectReference
+    // Since Policy is a singleton, this is sufficient knowledge to locate a role
+    // RoleRefs can only reference the current namespace and the global namespace
+    // If the RoleRef cannot be resolved, the Authorizer must return an error.
+    RoleRef kapi.ObjectReference
 }
 
 // Policy is a object that holds all the Roles for a particular namespace.  There is at most
 // one Policy document per namespace.
 type Policy struct {
-	kapi.TypeMeta
-	kapi.ObjectMeta
+    kapi.TypeMeta
+    kapi.ObjectMeta
 
-	// LastModified is the last time that any part of the Policy was created, updated, or deleted
-	LastModified util.Time
+    // LastModified is the last time that any part of the Policy was created, updated, or deleted
+    LastModified util.Time
 
-	// Roles holds all the Roles held by this Policy, mapped by Role.Name
-	Roles map[string]Role
+    // Roles holds all the Roles held by this Policy, mapped by Role.Name
+    Roles map[string]Role
 }
 
 // PolicyBinding is a object that holds all the RoleBindings for a particular namespace.  There is
 // one PolicyBinding document per referenced Policy namespace
 type PolicyBinding struct {
-	kapi.TypeMeta
-	kapi.ObjectMeta
+    kapi.TypeMeta
+    kapi.ObjectMeta
 
-	// LastModified is the last time that any part of the PolicyBinding was created, updated, or deleted
-	LastModified util.Time
+    // LastModified is the last time that any part of the PolicyBinding was created, updated, or deleted
+    LastModified util.Time
 
-	// PolicyRef is a reference to the Policy that contains all the Roles that this PolicyBinding's RoleBindings may reference
-	PolicyRef kapi.ObjectReference
-	// RoleBindings holds all the RoleBindings held by this PolicyBinding, mapped by RoleBinding.Name
-	RoleBindings map[string]RoleBinding
+    // PolicyRef is a reference to the Policy that contains all the Roles that this PolicyBinding's RoleBindings may reference
+    PolicyRef kapi.ObjectReference
+    // RoleBindings holds all the RoleBindings held by this PolicyBinding, mapped by RoleBinding.Name
+    RoleBindings map[string]RoleBinding
 }
 ```
 
@@ -204,10 +204,10 @@ This API answers the question: which users and groups can perform the specified 
 ```
 // input
 {
-	"kind": "ResourceAccessReview",
-	"apiVersion": "v1",
-	"verb": "list",
-	"resource": "replicationcontrollers"
+    "kind": "ResourceAccessReview",
+    "apiVersion": "v1",
+    "verb": "list",
+    "resource": "replicationcontrollers"
 }
 
 // POSTed like this
@@ -217,11 +217,11 @@ accessReviewResult, err := Client.ResourceAccessReviews(namespace).Create(resour
 
 // output
 {
-	"kind": "ResourceAccessReviewResponse",
-	"apiVersion": "v1",
-	"namespace": "default"
-	"users": ["Clark", "Hubert"],
-	"groups": ["cluster-admins"]
+    "kind": "ResourceAccessReviewResponse",
+    "apiVersion": "v1",
+    "namespace": "default"
+    "users": ["Clark", "Hubert"],
+    "groups": ["cluster-admins"]
 }
 ```
 
@@ -230,28 +230,28 @@ The actual Go objects look like this:
 // ResourceAccessReview is a means to request a list of which users and groups are authorized to perform the
 // action specified by spec
 type ResourceAccessReview struct {
-	kapi.TypeMeta
+    kapi.TypeMeta
 
-	// Verb is one of: get, list, watch, create, update, delete
-	Verb string
-	// Resource is one of the existing resource types
-	Resource string
-	// Content is the actual content of the request for create and update
-	Content runtime.EmbeddedObject
-	// ResourceName is the name of the resource being requested for a "get" or deleted for a "delete"
-	ResourceName string
+    // Verb is one of: get, list, watch, create, update, delete
+    Verb string
+    // Resource is one of the existing resource types
+    Resource string
+    // Content is the actual content of the request for create and update
+    Content runtime.EmbeddedObject
+    // ResourceName is the name of the resource being requested for a "get" or deleted for a "delete"
+    ResourceName string
 }
 
 // ResourceAccessReviewResponse describes who can perform the action
 type ResourceAccessReviewResponse struct {
-	kapi.TypeMeta
+    kapi.TypeMeta
 
-	// Namespace is the namespace used for the access review
-	Namespace string
-	// Users is the list of users who can perform the action
-	Users util.StringSet
-	// Groups is the list of groups who can perform the action
-	Groups util.StringSet
+    // Namespace is the namespace used for the access review
+    Namespace string
+    // Users is the list of users who can perform the action
+    Users util.StringSet
+    // Groups is the list of groups who can perform the action
+    Groups util.StringSet
 }
 ```
 Verbs are the standard RESTStorage verbs: get, list, watch, create, update, and delete.
@@ -261,16 +261,16 @@ This API answers the question: can a user or group (use authenticated user if no
 ```
 // input
 {
-	"kind": "SubjectAccessReview",
-	"apiVersion": "v1",
-	"verb": "create",
-	"resource": "pods",
-	"user": "Clark",
-	"content": {
-		"kind": "pods",
-		"apiVersion": "v1"
-		// rest of pod content
-	}
+    "kind": "SubjectAccessReview",
+    "apiVersion": "v1",
+    "verb": "create",
+    "resource": "pods",
+    "user": "Clark",
+    "content": {
+        "kind": "pods",
+        "apiVersion": "v1"
+        // rest of pod content
+    }
 }
 
 // POSTed like this
@@ -280,10 +280,10 @@ accessReviewResult, err := Client.SubjectAccessReviews(namespace).Create(subject
 
 // output
 {
-	"kind": "SubjectAccessReviewResponse",
-	"apiVersion": "v1",
-	"namespace": "default",
-	"allowed": true
+    "kind": "SubjectAccessReviewResponse",
+    "apiVersion": "v1",
+    "namespace": "default",
+    "allowed": true
 }
 ```
 
@@ -291,32 +291,32 @@ The actual Go objects look like this:
 ```
 // SubjectAccessReview is an object for requesting information about whether a user or group can perform an action
 type SubjectAccessReview struct {
-	kapi.TypeMeta
+    kapi.TypeMeta
 
-	// Verb is one of: get, list, watch, create, update, delete
-	Verb string
-	// Resource is one of the existing resource types
-	Resource string
-	// User is optional.  If both User and Groups are empty, the current authenticated user is used.
-	User string
-	// Groups is optional.  Groups is the list of groups to which the User belongs.
-	Groups util.StringSet
-	// Content is the actual content of the request for create and update
-	Content runtime.EmbeddedObject
-	// ResourceName is the name of the resource being requested for a "get" or deleted for a "delete"
-	ResourceName string
+    // Verb is one of: get, list, watch, create, update, delete
+    Verb string
+    // Resource is one of the existing resource types
+    Resource string
+    // User is optional.  If both User and Groups are empty, the current authenticated user is used.
+    User string
+    // Groups is optional.  Groups is the list of groups to which the User belongs.
+    Groups util.StringSet
+    // Content is the actual content of the request for create and update
+    Content runtime.EmbeddedObject
+    // ResourceName is the name of the resource being requested for a "get" or deleted for a "delete"
+    ResourceName string
 }
 
 // SubjectAccessReviewResponse describes whether or not a user or group can perform an action
 type SubjectAccessReviewResponse struct {
-	kapi.TypeMeta
+    kapi.TypeMeta
 
-	// Namespace is the namespace used for the access review
-	Namespace string
-	// Allowed is required.  True if the action would be allowed, false otherwise.
-	Allowed bool
-	// Reason is optional.  It indicates why a request was allowed or denied.
-	Reason string
+    // Namespace is the namespace used for the access review
+    Namespace string
+    // Allowed is required.  True if the action would be allowed, false otherwise.
+    Allowed bool
+    // Reason is optional.  It indicates why a request was allowed or denied.
+    Reason string
 }
 ```
 
@@ -325,31 +325,31 @@ type SubjectAccessReviewResponse struct {
 ### Runtime Authorization Types
 ```
 type Authorizer interface{
-	// Authorize indicates whether an action is allowed or not and optionally a reason for allowing or denying.
-	Authorize(a AuthorizationAttributes) (allowed bool, reason string, err error)
+    // Authorize indicates whether an action is allowed or not and optionally a reason for allowing or denying.
+    Authorize(a AuthorizationAttributes) (allowed bool, reason string, err error)
 
-	// GetAllowedSubjects takes a set of attributes, ignores the UserInfo() and returns back
-	// the users and groups who are allowed to make a request that has those attributes.  This
-	// API enables the ResourceBasedReview requests below
-	GetAllowedSubjects(attributes AuthorizationAttributes) (users util.StringSet, groups util.StringSet, error)
+    // GetAllowedSubjects takes a set of attributes, ignores the UserInfo() and returns back
+    // the users and groups who are allowed to make a request that has those attributes.  This
+    // API enables the ResourceBasedReview requests below
+    GetAllowedSubjects(attributes AuthorizationAttributes) (users util.StringSet, groups util.StringSet, error)
 }
 
 // AuthorizationAttributeBuilder takes a request and creates AuthorizationAttributes.
 // Since the attributes returned can vary based on verb type, AuthorizationAttributeBuilders
 // are paired with Authorizers during registration.
 type AuthorizationAttributeBuilder interface{
-	GetAttributes(request http.Request) (AuthorizationAttributes, error)
+    GetAttributes(request http.Request) (AuthorizationAttributes, error)
 }
 
 type AuthorizationAttributes interface{
-	GetUserInfo() UserInfo  // includes GetName() string GetGroups() []string
-	GetVerb() string
-	GetNamespace() string
-	GetResourceKind() string
-	GetResourceName() string
-	// GetRequestAttributes is of type interface{} because different verbs and different
-	// Authorizer/AuthorizationAttributeBuilder pairs may have different contract requirements
-	GetRequestAttributes() interface{}
+    GetUserInfo() UserInfo  // includes GetName() string GetGroups() []string
+    GetVerb() string
+    GetNamespace() string
+    GetResourceKind() string
+    GetResourceName() string
+    // GetRequestAttributes is of type interface{} because different verbs and different
+    // Authorizer/AuthorizationAttributeBuilder pairs may have different contract requirements
+    GetRequestAttributes() interface{}
 }
 ```
 A single Authorizer/AuthorizationAttributeBuilder pair may be registered with the apiserver.
@@ -364,14 +364,14 @@ We can continue the simple example from above with `Clark` the cluster admin, `H
 By default, `Hubert` does not have sufficient power to create new Roles because there is not an existing Policy object in the `hammer` namespace.  `Hubert` has rights to create Roles, but the requests don't work because no existing Policy object exist.  `Clark` must first create a Policy and a PolicyBinding object:
 ```
 {
-	"kind": "Policy",
-	"name": "Policy",
-	"namespace": "hammer"
+    "kind": "Policy",
+    "name": "Policy",
+    "namespace": "hammer"
 }
 {
-	"kind": "PolicyBinding",
-	"name": "hammer",
-	"namespace": "hammer"
+    "kind": "PolicyBinding",
+    "name": "hammer",
+    "namespace": "hammer"
 }
 ```
 
@@ -380,23 +380,23 @@ Once those container resources are created, `Hubert` can now create Roles and Ro
 `Hubert` wants to create a bot that only has permission to touch labels on DeploymentConfigs.  He can create a role like this (note that a role is required because we want to have a set of two rules):
 ```
 {
-	"kind": "role",
-	"name": "deploymentConfigLabelers",
-	"namespace": "hammer",
-	"rules": [
-		{ "verbs": ["watch", "list", "get"], "resources": ["deploymentconfigs"] },
-		{ "verbs": ["update"], "resources": ["deploymentconfigs"], "attributeRestrictions" : {"fieldsMutatable": ["labels"]} }
-	]
+    "kind": "role",
+    "name": "deploymentConfigLabelers",
+    "namespace": "hammer",
+    "rules": [
+        { "verbs": ["watch", "list", "get"], "resources": ["deploymentconfigs"] },
+        { "verbs": ["update"], "resources": ["deploymentconfigs"], "attributeRestrictions" : {"fieldsMutatable": ["labels"]} }
+    ]
 }
 {
-	"kind": "roleBinding",
-	"name": "DeploymentConfigLabelerBots",
-	"namespace": "hammer",
-	"roleRef": {
-		"namespace": "hammer",
-		"name": "deploymentConfigLabelers"
-	}
-	"userNames": ["ProtectorBot", "DeprotectorBot"]
+    "kind": "roleBinding",
+    "name": "DeploymentConfigLabelerBots",
+    "namespace": "hammer",
+    "roleRef": {
+        "namespace": "hammer",
+        "name": "deploymentConfigLabelers"
+    }
+    "userNames": ["ProtectorBot", "DeprotectorBot"]
 }
 ```
 
@@ -404,28 +404,28 @@ Once those container resources are created, `Hubert` can now create Roles and Ro
 In addition to constraining basic resources, there are some rules that are more difficult to request.  For some of these, it is easier to build a special evaluation method than trying to specify a generic set of property to express the restriction.  One way to express this is to create a rule for each individual pod that allows that particular kubelet use to access it.  This results in a tremendous number of rules and a lot of churn in the rules themselves.  Rather than do this, we can add a special kind of AttributeRestriction to a single rule.
 ```
 {
-	"kind": "role",
-	"name": "kubelet",
-	"namespace": "master",
-	"rules": [
-		{
-			"verbs": ["*"],
-			"resources": ["pods"],
-			"attributeRestrictions": {
-				"kind": "sameMinionRestriction"
-			}
-		},
-	]
+    "kind": "role",
+    "name": "kubelet",
+    "namespace": "master",
+    "rules": [
+        {
+            "verbs": ["*"],
+            "resources": ["pods"],
+            "attributeRestrictions": {
+                "kind": "sameMinionRestriction"
+            }
+        },
+    ]
 }
 {
-	"kind": "roleBinding",
-	"name": "Kubelets",
-	"namespace": "master",
-	"roleRef": {
-		"namespace": "master",
-		"name": "kubelet"
-	}
-	"userNames": ["kubelet-01", "kubelet-02"]
+    "kind": "roleBinding",
+    "name": "Kubelets",
+    "namespace": "master",
+    "roleRef": {
+        "namespace": "master",
+        "name": "kubelet"
+    }
+    "userNames": ["kubelet-01", "kubelet-02"]
 }
 ```
 
@@ -433,19 +433,19 @@ When Authorizer.Authorize() is called, it will see a
 ```
 // pretend authorizationAttributes
 {
-	"user": "kubelet",
-	"verb": "get",
-	"namespace": "pod's namespace",
-	"resourceKind": "pod"
+    "user": "kubelet",
+    "verb": "get",
+    "namespace": "pod's namespace",
+    "resourceKind": "pod"
 }
 
 // kubelet policy rule it extracted based on the role
 {
-	"verbs": ["*"],
-	"resources": ["Pod"],
-	"attributeRestrictions": {
-		"kind": "sameMinionRestriction"
-	}
+    "verbs": ["*"],
+    "resources": ["Pod"],
+    "attributeRestrictions": {
+        "kind": "sameMinionRestriction"
+    }
 },
 
 ```
@@ -454,11 +454,11 @@ Based on this information, the authorizer will know that it has to locate and ev
 // pseudo code
 switch policyRule.AttributeRestrictions.(type){
 case "sameMinionRestriction":
-	// check to see if the user is kubelet, if not fail
-	// check which minion the kubelet is running on
-	// get the pod that the minion is trying to modify
-	// check to see if that pod is running on the same minion as the kubelet
-	// if so, return authorized.  if not, return denied
+    // check to see if the user is kubelet, if not fail
+    // check which minion the kubelet is running on
+    // get the pod that the minion is trying to modify
+    // check to see if that pod is running on the same minion as the kubelet
+    // if so, return authorized.  if not, return denied
 }
 
 // do normal resource kind restrictions

--- a/docs/proposals/security-context-constraints.md
+++ b/docs/proposals/security-context-constraints.md
@@ -81,51 +81,51 @@ account or by a group containing all service accounts.
 // SecurityContextConstraints governs the ability to make requests that affect the SecurityContext that will
 // be applied to a container.
 type SecurityContextConstraints struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+    TypeMeta   `json:",inline"`
+    ObjectMeta `json:"metadata,omitempty"`
 
-	// AllowPrivilegedContainer determines if a container can request to be run as privileged.
-	AllowPrivilegedContainer bool `json:"allowPrivilegedContainer,omitempty" description:"allow containers to run as privileged"`
-	// AllowedCapabilities is a list of capabilities that can be requested to add to the container.
-	AllowedCapabilities []CapabilityType `json:"allowedCapabilities,omitempty" description:"capabilities that are allowed to be added"`
-	// AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin
-	AllowHostDirVolumePlugin bool `json:"allowHostDirVolumePlugin,omitempty" description:"allow the use of the host dir volume plugin"`
-	// SELinuxContext is the strategy that will dictate what labels will be set in the SecurityContext.
-	SELinuxContext SELinuxContextStrategyOptions `json:"seLinuxContext,omitempty" description:"strategy used to generate SELinuxOptions"`
-	// RunAsUser is the strategy that will dictate what RunAsUser is used in the SecurityContext.
-	RunAsUser RunAsUserStrategyOptions `json:"runAsUser,omitempty" description:"strategy used to generate RunAsUser"`
+    // AllowPrivilegedContainer determines if a container can request to be run as privileged.
+    AllowPrivilegedContainer bool `json:"allowPrivilegedContainer,omitempty" description:"allow containers to run as privileged"`
+    // AllowedCapabilities is a list of capabilities that can be requested to add to the container.
+    AllowedCapabilities []CapabilityType `json:"allowedCapabilities,omitempty" description:"capabilities that are allowed to be added"`
+    // AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin
+    AllowHostDirVolumePlugin bool `json:"allowHostDirVolumePlugin,omitempty" description:"allow the use of the host dir volume plugin"`
+    // SELinuxContext is the strategy that will dictate what labels will be set in the SecurityContext.
+    SELinuxContext SELinuxContextStrategyOptions `json:"seLinuxContext,omitempty" description:"strategy used to generate SELinuxOptions"`
+    // RunAsUser is the strategy that will dictate what RunAsUser is used in the SecurityContext.
+    RunAsUser RunAsUserStrategyOptions `json:"runAsUser,omitempty" description:"strategy used to generate RunAsUser"`
 
-	// The users who have permissions to use this security context constraints
-	Users []string `json:"users,omitempty" description:"users allowed to use this SecurityContextConstraints"`
-	// The groups that have permission to use this security context constraints
-	Groups []string `json:"groups,omitempty" description:"groups allowed to use this SecurityContextConstraints"`
+    // The users who have permissions to use this security context constraints
+    Users []string `json:"users,omitempty" description:"users allowed to use this SecurityContextConstraints"`
+    // The groups that have permission to use this security context constraints
+    Groups []string `json:"groups,omitempty" description:"groups allowed to use this SecurityContextConstraints"`
 }
 
 // SELinuxContextStrategyOptions defines the strategy type and any options used to create the strategy.
 type SELinuxContextStrategyOptions struct {
-	// Type is the strategy that will dictate what SELinux context is used in the SecurityContext.
-	Type SELinuxContextStrategyType `json:"type,omitempty" description:"strategy used to generate the SELinux context"`
+    // Type is the strategy that will dictate what SELinux context is used in the SecurityContext.
+    Type SELinuxContextStrategyType `json:"type,omitempty" description:"strategy used to generate the SELinux context"`
 
-	//TODO
+    //TODO
 }
 
 // RunAsUserStrategyOptions defines the strategy type and any options used to create the strategy.
 type RunAsUserStrategyOptions struct {
-	// Type is the strategy that will dictate what RunAsUser is used in the SecurityContext.
-	Type RunAsUserStrategyType `json:"type,omitempty" description:"strategy used to generate RunAsUser"`
-	// UID is the user id that containers must run as.  Required for the MustRunAs strategy if not using
-	// namespace/service account allocated uids.
-	UID *int64 `json:"uid,omitempty" description:"the uid to always run as; required for MustRunAs"`
-	// AllocatedIDAnnotation provides an annotation that the strategy can look for if it should
-	// use a pre-allocated UID that exists on the namespace or service account.
-	AllocatedIDAnnotation string `json:"allocatedIDAnnotation,omitempty" description:"how the strategy can discover pre-allocated ids on the namespace or service account"`
-	// UIDRangeMin defines the min value for a strategy that allocates by range.
-	UIDRangeMin int64 `json:"uidRangeMin,omitempty" description:"min value for range based allocators"`
-	// UIDRangeMax defines the max value for a strategy that allocates by range.
-	UIDRangeMax int64 `json:"uidRangeMax,omitempty" description:"max value for range based allocators"`
-	// UIDRangeAnnotation provides an annotation that the strategy can look for if ranges
-	// are preallocated and assigned to the namespace or service account.
-	UIDRangeAnnotation string `json:"uidRangeAnnotation,omitempty" description:"how the strategy can discover pre-allocated ranges on the namespace or service account"`
+    // Type is the strategy that will dictate what RunAsUser is used in the SecurityContext.
+    Type RunAsUserStrategyType `json:"type,omitempty" description:"strategy used to generate RunAsUser"`
+    // UID is the user id that containers must run as.  Required for the MustRunAs strategy if not using
+    // namespace/service account allocated uids.
+    UID *int64 `json:"uid,omitempty" description:"the uid to always run as; required for MustRunAs"`
+    // AllocatedIDAnnotation provides an annotation that the strategy can look for if it should
+    // use a pre-allocated UID that exists on the namespace or service account.
+    AllocatedIDAnnotation string `json:"allocatedIDAnnotation,omitempty" description:"how the strategy can discover pre-allocated ids on the namespace or service account"`
+    // UIDRangeMin defines the min value for a strategy that allocates by range.
+    UIDRangeMin int64 `json:"uidRangeMin,omitempty" description:"min value for range based allocators"`
+    // UIDRangeMax defines the max value for a strategy that allocates by range.
+    UIDRangeMax int64 `json:"uidRangeMax,omitempty" description:"max value for range based allocators"`
+    // UIDRangeAnnotation provides an annotation that the strategy can look for if ranges
+    // are preallocated and assigned to the namespace or service account.
+    UIDRangeAnnotation string `json:"uidRangeAnnotation,omitempty" description:"how the strategy can discover pre-allocated ranges on the namespace or service account"`
 }
 
 // SELinuxContextStrategyType denotes strategy types for generating SELinux options for a
@@ -139,10 +139,10 @@ type RunAsUserStrategyType string
 // SecurityContextConstraintsAllocator provides the implementation to generate a new security
 // context based on constraints or validate an existing security context against constraints.
 type SecurityContextConstraintsAllocator interface {
-	// Create a SecurityContext based on the given constraints
-	CreateSecurityContext(pod *api.Pod, container *api.Container, constraints *api.SecurityContextConstraints) (*api.SecurityContext, error)
-	// Ensure a container's SecurityContext is in compliance with the given constraints
-	ValidateSecurityContext(pod *api.Pod, container *api.Container, constraints *api.SecurityContextConstraints) fielderrors.ValidationErrorList
+    // Create a SecurityContext based on the given constraints
+    CreateSecurityContext(pod *api.Pod, container *api.Container, constraints *api.SecurityContextConstraints) (*api.SecurityContext, error)
+    // Ensure a container's SecurityContext is in compliance with the given constraints
+    ValidateSecurityContext(pod *api.Pod, container *api.Container, constraints *api.SecurityContextConstraints) fielderrors.ValidationErrorList
 }
 
 const (
@@ -260,18 +260,18 @@ the settings fall within the allowed values or create a new value.
 ```go
 // SELinuxSecurityContextConstraintsStrategy defines the interface for all SELinux constraint strategies.
 type SELinuxSecurityContextConstraintsStrategy interface {
-	// Generate creates the SELinuxOptions based on constraint rules.
-	Generate(pod *api.Pod, container *api.Container)  (*api.SELinuxOptions, error)
-	// Validate ensures that the specified values fall within the range of the strategy.
-	Validate(pod *api.Pod, container *api.Container) fielderrors.ValidationErrorList
+    // Generate creates the SELinuxOptions based on constraint rules.
+    Generate(pod *api.Pod, container *api.Container)  (*api.SELinuxOptions, error)
+    // Validate ensures that the specified values fall within the range of the strategy.
+    Validate(pod *api.Pod, container *api.Container) fielderrors.ValidationErrorList
 }
 
 // RunAsUserSecurityContextConstraintsStrategy defines the interface for all uid constraint strategies.
 type RunAsUserSecurityContextConstraintsStrategy interface {
-	// Generate creates the uid based on policy rules.
-	Generate(pod *api.Pod, container *api.Container) (*int64, error)
-	// Validate ensures that the specified values fall within the range of the strategy.
-	Validate(pod *api.Pod, container *api.Container) fielderrors.ValidationErrorList
+    // Generate creates the uid based on policy rules.
+    Generate(pod *api.Pod, container *api.Container) (*int64, error)
+    // Validate ensures that the specified values fall within the range of the strategy.
+    Validate(pod *api.Pod, container *api.Container) fielderrors.ValidationErrorList
 }
 ```
 

--- a/docs/proposals/shared-quota.md
+++ b/docs/proposals/shared-quota.md
@@ -11,35 +11,35 @@ By associating projects to owners using structured labels, it becomes possible t
 // ClusterResourceQuota mirrors ResourceQuota at a cluster scope.  This object is easily convertible to 
 // synthetic ResourceQuota object to allow quota evaluation re-use.
 type ClusterResourceQuota struct {
-	unversioned.TypeMeta
-	kapi.ObjectMeta
+    unversioned.TypeMeta
+    kapi.ObjectMeta
 
-	// Spec defines the desired quota
-	Spec ClusterResourceQuotaSpec
+    // Spec defines the desired quota
+    Spec ClusterResourceQuotaSpec
 
-	// Status defines the actual enforced quota and its current usage
-	Status ClusterResourceQuotaStatus
+    // Status defines the actual enforced quota and its current usage
+    Status ClusterResourceQuotaStatus
 }
 
 type ClusterResourceQuotaSpec struct {
-	// Selector is the label selector used to match projects.  It is not allowed to be empty
-	// and should only select active projects on the scale of dozens (though it can select 
-	// many more less active projects).  These projects will contend on object creation through
-	// this resource.
-	Selector map[string]string
+    // Selector is the label selector used to match projects.  It is not allowed to be empty
+    // and should only select active projects on the scale of dozens (though it can select 
+    // many more less active projects).  These projects will contend on object creation through
+    // this resource.
+    Selector map[string]string
 
-	// Spec defines the desired quota
-	Quota kapi.ResourceQuotaSpec
+    // Spec defines the desired quota
+    Quota kapi.ResourceQuotaSpec
 }
 
 type ClusterResourceQuotaStatus struct {
-	// Overall defines the actual enforced quota and its current usage across all namespaces
-	Overall kapi.ResourceQuotaStatus
+    // Overall defines the actual enforced quota and its current usage across all namespaces
+    Overall kapi.ResourceQuotaStatus
 
-	// ByNamespace slices the usage by namespace.  This division allows for quick resolution of 
-	// deletion reconcilation inside of a single namespace without requiring a recalculation 
-	// across all namespaces.  This map can be used to pull the deltas for a given namespace.
-	ByNamespace map[string]kapi.ResourceQuotaStatus
+    // ByNamespace slices the usage by namespace.  This division allows for quick resolution of 
+    // deletion reconcilation inside of a single namespace without requiring a recalculation 
+    // across all namespaces.  This map can be used to pull the deltas for a given namespace.
+    ByNamespace map[string]kapi.ResourceQuotaStatus
 }
 ```
 


### PR DESCRIPTION
Spaces, it is aligned to view code with any editor, including the web
page view (such as in the GitHub code). When use tabs, the view on the
page is chaos, and it is terrible to mix tabs and spaces.